### PR TITLE
Clarify empty match arm format

### DIFF
--- a/guide/expressions.md
+++ b/guide/expressions.md
@@ -638,6 +638,8 @@ a block.
 
 The body of a block arm should be block indented once.
 
+An empty match arm should be written as `pattern => {}`.
+
 Examples:
 
 ```rust


### PR DESCRIPTION
Prefer `pattern => {}` over `pattern => ()`.

Fixes https://github.com/rust-dev-tools/fmt-rfcs/issues/146.