### PR TITLE
Update broken link

### DIFF
--- a/guide/cargo.md
+++ b/guide/cargo.md
@@ -17,8 +17,7 @@ followed by the `description` at the end of that section.
 Don't use quotes around any standard key names; use bare keys. Only use quoted
 keys for non-standard keys whose names require them, and avoid introducing such
 key names when possible.  See the [TOML
-specification](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md#table)
-for details.
+specification](https://toml.io/en/v1.0.0#keys) for details.
 
 Put a single space both before and after the `=` between a key and value. Do
 not indent any key names; start all key names at the start of a line.


### PR DESCRIPTION
Toml now uses toml.io for released specifications and the github repo for development.  Also the old link was for the 0.4 specification, while cargo uses toml_edit, which uses toml 1.0 (reference: https://github.com/toml-rs/toml/blob/main/crates/toml_edit/CHANGELOG.md#030---2021-09-13). Finally, the link was referring to discussion of "Bare keys" vs "Quoted keys".  This discussion was in the `#table` section in the 0.4 specification, but is under `#keys` in the 1.0 specification.