### PR TITLE
Fix links

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -8,15 +8,15 @@
 
 ## Domains
 
-1. [Style Guide](https://github.com/rust-lang/fmt-rfcs/blob/master/guide/guide.md)
-2. [T-style team repo](https://github.com/rust-lang/fmt-rfcs/)
+1. [Style Guide](https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src)
+2. [T-style team repo](https://github.com/rust-lang/style-team/)
 3. [#T-style](https://rust-lang.zulipchat.com/#narrow/stream/346005-t-style) Zulip stream
 4. [#T-style/private](https://rust-lang.zulipchat.com/#narrow/stream/353175-t-style.2Fprivate) Zulip stream
 5. `rust-lang` issues with the `T-style` or `I-style-nominated` labels
 
 ## Membership
 
-The active membership of the style team can be found on [rust-lang.org/governance](https://github.com/rust-lang/team/blob/master/teams/style.toml).
+The active membership of the style team can be found on [rust-lang.org/governance](https://github.com/rust-lang/team/blob/HEAD/teams/style.toml).
 
 The Rust style team shall have at least 3 members and at most 8. If the team has fewer than 3 members it shall seek new members as its primary focus.
 

--- a/team-policy.md
+++ b/team-policy.md
@@ -3,7 +3,7 @@
 This is a living document tracking the active policies of the style team. It is intended to fill a similar role to the books that many[^1] teams[^2] maintain[^3] independently[^4]. If in the future Rust establishes central linking/indexing/aggregating of policies, these will need to appear there.
 
 * **Original RFC**: https://rust-lang.github.io/rfcs/3309-style-team.html
-* **Charter**: https://github.com/rust-lang/fmt-rfcs/blob/master/charter.md
+* **Charter**: https://github.com/rust-lang/style-team/blob/HEAD/charter.md
 
 ## Style Guide Evolution
 
@@ -158,7 +158,7 @@ Meeting evaluations are an opportunity to learn from our meetings. We can either
 
 Meeting check-outs are considered private and internal to the style team and are not recorded as part of our minutes. Exceptions to this can be made via an operational consent decision by the team, and are often useful in cases such as when new backlog or action items come up during the check-out.
 
-[Style Guide]: https://github.com/rust-lang/fmt-rfcs/blob/master/guide/guide.md
+[Style Guide]: https://github.com/rust-lang/rust/tree/HEAD/src/doc/style-guide/src
 [#T-style]: https://rust-lang.zulipchat.com/#narrow/stream/346005-t-style
 
 [^1]: https://rust-lang.github.io/compiler-team/


### PR DESCRIPTION
The style guide no longer lives in this repo; change references to the
style guide to point to it in rust-lang/rust.

Change fmt-rfcs to style-team everywhere it appears (except README,
which needs an overhaul).

Change references to the HEAD branch of repositories to use `HEAD`
rather than the name of the branch, to make it easy to rename.
